### PR TITLE
Allow setting which image to use

### DIFF
--- a/MMM-WeatherBackground.js
+++ b/MMM-WeatherBackground.js
@@ -31,6 +31,7 @@ Module.register("MMM-WeatherBackground", {
     externalCollections: "collections.json", // or null
     collections: {},
     clientID: "",
+    unsplashSize: "full",
     sources: {
       weather: {
         notification: "CURRENTWEATHER_TYPE",
@@ -208,6 +209,19 @@ Module.register("MMM-WeatherBackground", {
     const response = await fetch(baseUrl + "?query=" + query + "&client_id=" + this.config.clientID)
     const data = await response.json()
 
-    return data.urls.full
+    switch(this.config.unsplashSize) {
+      case "raw":
+        return data.urls.raw
+      case "full":
+        return data.urls.full
+      case "regular":
+        return data.urls.regular
+      case "small":
+        return data.urls.small
+      case "thumb":
+        return data.urls.thumb
+      default:
+        return data.urls.full
+    }
   }
 });


### PR DESCRIPTION
The unsplash API supports the following (https://unsplash.com/documentation#example-image-use): 

- `full` returns the photo in jpg format with its maximum dimensions. For performance purposes, we don’t recommend using this as the photos will load slowly for your users.
- `regular` returns the photo in jpg format with a width of 1080 pixels.
- `small` returns the photo in jpg format with a width of 400 pixels.
- `thumb` returns the photo in jpg format with a width of 200 pixels.
- `raw` returns a base image URL with just the photo path and the ixid parameter for your API application. Use this to easily add additional image parameters to construct your own image URL.


This module currently always uses the `full` photo. On a lower-power device or a smaller screen, this is less optimal and probably results in using more RAM and network bandwidth than necessary.

This PR adds in a new config item `unsplashSize` (not a great name, but I couldn't think of anything else) which allows you to specify one of the above settings. The default remains `full`

I'll note that the current `size` config item appears to be entirely unused, so possibly we could just repurpose that